### PR TITLE
Fix Client SDK Generation

### DIFF
--- a/.devops/deploy-pipelines.yml
+++ b/.devops/deploy-pipelines.yml
@@ -190,3 +190,4 @@ stages:
         - template: templates/client-sdk-publish/template.yaml@pagopaCommons
           parameters:
             openapiSpecPath: 'openapi/index.yaml'
+            generatorPackageName: 'italia-utils'


### PR DESCRIPTION
Make client SDK generation template italia-utils instead of @pagopa/openapi-codegen-ts, to avoid generation errors